### PR TITLE
Hash out the many contribution-related stats

### DIFF
--- a/Game_Manual/Boundaries.md
+++ b/Game_Manual/Boundaries.md
@@ -26,7 +26,7 @@ Fail conditions are triggered when any of the following persists over multiple c
 1. Rate of [XP][xp] growth is too low
 1. [Learning Support][learning-support] is too low
 1. [Culture Contribution][culture-contribution] is too low
-1. [Discernment][discernment] is too high
+1. [Estimation Accuracy][estimation-accuracy] is too high
 
 If fail conditions are met, the Moderator will ask the player to leave the game.
 
@@ -37,6 +37,6 @@ _For now, since we have very little historical data tracking stats, "too high" a
 [xp]: ./Stats#xp
 [learning-support]: ./Stats#learning-support
 [culture-contribution]: ./Stats#culture-contribution
-[discernment]: ./Stats#discernment
+[estimation-accuracy]: ./Stats#estimation-accuracy
 
 [cos-conflict-resolution-process]: http://cos.learnersguild.org/Processes/Conflict.html

--- a/Game_Manual/Boundaries.md
+++ b/Game_Manual/Boundaries.md
@@ -26,7 +26,7 @@ Fail conditions are triggered when any of the following persists over multiple c
 1. Rate of [XP][xp] growth is too low
 1. [Learning Support][learning-support] is too low
 1. [Culture Contribution][culture-contribution] is too low
-1. [Estimation Accuracy][estimation-accuracy] is too high
+1. [Estimation Accuracy][estimation-accuracy] is too low
 
 If fail conditions are met, the Moderator will ask the player to leave the game.
 

--- a/Game_Manual/Stats.md
+++ b/Game_Manual/Stats.md
@@ -23,11 +23,11 @@ The average % quality of all projects you've worked on.
 
 ## Learning Support
 
-How much your team members felt that you supported them in their learning. This is a weighted average with more recent projects counting more than earlier ones. Represented as a percentage (0-100%).
+How much your team members felt that you supported them in their learning. This is a weighted average with more recent projects counting more than earlier ones. Represented as a percentage (0..100%).
 
 ## Culture Contribution
 
-How much your team members felt you contributed positively to the team culture. This is a weighted average with more recent projects counting more than earlier ones. Represented as a percentage (0-100%).
+How much your team members felt you contributed positively to the team culture. This is a weighted average with more recent projects counting more than earlier ones. Represented as a percentage (0..100%).
 
 ## Project Contribution
 
@@ -47,25 +47,25 @@ To demonstrate how the various contribution stats are calculated, we'll use the 
 
 ### Actual Contribution
 
-Your actual contribution is the average of your team's estimates of what percentage of the project you contributed to. It includes your own estimate of your contribution. Represented as a percentage (0-100%).
+Your actual contribution is the average of your team's estimates of what percentage of the project you contributed to. It includes your own estimate of your contribution. Represented as a percentage (0..100%).
 
-In the above dataset, the player's actual contribution for the `#big-bees` project is the mean of _all_ the estimates, so it would be equal to 46.67% ( (50% + 42% + 48%) / 3 ).
+In the above dataset, the player's actual contribution for the `#big-bees` project is the average of _all_ the estimates, so it would be equal to 46.67% ( (50% + 42% + 48%) / 3 ).
 
 ### Expected Contribution
 
-Your expected contribution how much you are expected to contribute to the project based on the team size so that each player contributes equally. Represented as a percentage (0-100%).
+Your expected contribution how much you are expected to contribute to the project based on the team size so that each player contributes equally. Represented as a percentage (0..100%).
 
 In the above dataset, the player's expected contribution for the `#big-bees` project is equal to 33.33% ( 100% / 3 ) because their team has 3 players, so an equal contribution is 1/3 of the project.
 
 ### Contribution Gap
 
-The contribution gap is the difference between actual and expected contribution. It demonstrates whether a player contributed _more_ or _less_ than is expected of them, based on the size of their team. Represented as a percentage (0-100%).
+The contribution gap is the difference between actual and expected contribution. It demonstrates whether a player contributed _more_ or _less_ than is expected of them, based on the size of their team. Represented as a percentage (0..100%).
 
 In the above dataset, the player's contribution gap for the `#big-bees` project is equal to 13.34% ( 46.67% - 33.33% ).
 
-## Contribution Accuracy and Bias
+## Estimation Accuracy and Bias
 
-Contribution accuracy and bias reflect how well you estimate your contribution to projects.
+Estimation accuracy and bias reflect how well you estimate your contribution to projects.
 
 To demonstrate how these stats apply, we'll use a modified version of the above dataset, aggregating the team estimates into their average (mean):
 
@@ -75,40 +75,47 @@ To demonstrate how these stats apply, we'll use a modified version of the above 
 | #red-rabbits | 28%           | 30%                 |
 | #tiny-tigers | 20%           | 30%                 |
 
-### Contribution Accuracy
+### Estimation Accuracy
 
-Contribution accuracy reflects how accurate your estimations are relative to the consensus. Represented as a percentage (0-100%).
+Estimation accuracy reflects how accurate your estimations are relative to the consensus. Represented as a percentage (0..100%).
 
 Zero is equal to perfect accuracy (i.e. you estimate your contribution the same as your peers do). The closer this stat is to zero, the more accurate your contribution estimates are.
 
-Your contribution accuracy _per project_ is the difference between self- and team-estimated contribution as an absolute number. So the contribution accuracy stats for the above projects would be:
+Your estimation accuracy _per project_ is the difference between self- and team-estimated contribution for that project, using the [absolute value][absolute-values] of that difference. So the estimation accuracy stats for the above projects would be:
 
-| Project      | Accuracy             |
-|:-------------|:---------------------|
-| #tiny-tigers | abs(20% - 30%) = 10% |
-| #big-bees    | abs(50% - 45%) = 5%  |
-| #red-rabbits | abs(28% - 30%) = 2%  |
+| Project      | Estimation Accuracy                  |
+|:-------------|:-------------------------------------|
+| #tiny-tigers | abs(20% - 30%) = abs(-10%) = **10%** |
+| #big-bees    | abs(50% - 45%) = abs(5%) = **5%**    |
+| #red-rabbits | abs(28% - 30%) = abs(-2%) = **2%**   |
 
-Based on these projects, the _overall contribution accuracy stat_ is 5.67% (mean of [10%, 5%, 2%]).
+Based on these projects, the _overall estimation accuracy stat_ is 5.67% (average of [10%, 5%, 2%]).
 
-## Contribution Bias
+## Estimation Bias
 
-Contribution bias reflects whether you tend to over- or under- estimate your contribution. Represented as a percentage (0-100%).
+Estimation bias reflects whether you tend to over- or under- estimate your contribution. Represented as a +/- percentage (-100%..100%).
 
-It is calculated the same as contribution accuracy, except that it does turn the difference into an absolute number.
+If your estimation bias is _below zero_, that means that you tend to underestimate your contribution to the projects that you work on. Your fellow players see value that you don't recognize; you can learn to take more credit for your work!
 
-Your contribution bias _per project_ is the difference between self- and team-estimated contribution. So the contribution bias stats for the above projects would be:
+If your estimation bias is _above zero_, that means that you tend to overestimate your contribution to the projects that you work on. Your fellow players don't think you deserve as much credit as you seem to want; you can learn to be more humble.
 
-| Project      | Bias             |
+If your estimation bias is _exactly zero_, congratulations! You must be a mind-reader, and/or exceptionally self-aware.
+
+Estimation bias is calculated the same as estimation accuracy, except that it does _not_ use the absolute values of the difference between self and team estimates.
+
+Your estimation bias _per project_ is the difference between self- and team-estimated contribution for that project. So the estimation bias stats for the above projects would be:
+
+| Project      | Estimation Bias  |
 |:-------------|:-----------------|
 | #tiny-tigers | 20% - 30% = -10% |
 | #big-bees    | 50% - 45% = 5%   |
 | #red-rabbits | 28% - 30% = -2%  |
 
-Based on these projects, the _overall contribution bias stat_ is -2.33% (mean of [-10%, 5%, -2%]).
+Based on these projects, the _overall estimation bias stat_ is -2.33% (average of [-10%, 5%, -2%]).
 
 ## Time Dedication per Week
 
 Average hours per week you spent contributing to team projects.
 
 [game-objectives]: ./Boundaries.md#objectives
+[absolute-values]: http://www.coolmath.com/algebra/18-absolute-value-equations-inequalities/01-absolute-values-01

--- a/Game_Manual/Stats.md
+++ b/Game_Manual/Stats.md
@@ -29,31 +29,83 @@ How much your team members felt that you supported them in their learning. This 
 
 How much your team members felt you contributed positively to the team culture. This is a weighted average with more recent projects counting more than earlier ones. Represented as a percentage (0-100%).
 
-## Discernment
+## Project Contribution
 
-Reflects the degree to which you are biased in your assessment of your contribution to projects (as compared to the average of others' assessment). Represented as a percentage corresponding to the average of how much you over- or under-estimate your contribution to projects.
+The amount that you contribute to a project determines a series of other stats, and also contains several sub-stats within.
 
-Zero is equal to perfect discernment (i.e. you estimate your contribution the same as your peers do). The closer this stat is to zero, the more accurate your discernment is.
+Within a given project, you have **actual** and **expected** contributions, as well as a **contribution gap**.
 
-#### Example
+To demonstrate how the various contribution stats are calculated, we'll use the following dataset in examples.
 
-Let's say you worked on three projects, with the following contribution rankings:
+#### Example Project Contribution Estimations
 
-| Project      | Contribution (self-estimated) | Contribution (team-estimated) |
-|:-------------|:------------------------------|:------------------------------|
-| #tiny-tigers | 20%                           | 30%                           |
-| #big-bees    | 50%                           | 45%                           |
-| #red-rabbits | 28%                           | 30%                           |
+| Project      | Team size | Self estimate | Team estimates |
+|:-------------|:----------|:--------------|:---------------|
+| #big-bees    | 3         | 50%           | 42%, 48%       |
+| #red-rabbits | 4         | 28%           | 27%, 35%, 28%  |
+| #tiny-tigers | 2         | 20%           | 30%            |
 
-Your discernment _per project_ is the difference between self- and team-estimated contribution as an absolute number. So the discernment stats for the above projects would be:
+### Actual Contribution
 
-| Project      | Discernment          |
+Your actual contribution is the average of your team's estimates of what percentage of the project you contributed to. It includes your own estimate of your contribution. Represented as a percentage (0-100%).
+
+In the above dataset, the player's actual contribution for the `#big-bees` project is the mean of _all_ the estimates, so it would be equal to 46.67% ( (50% + 42% + 48%) / 3 ).
+
+### Expected Contribution
+
+Your expected contribution how much you are expected to contribute to the project based on the team size so that each player contributes equally. Represented as a percentage (0-100%).
+
+In the above dataset, the player's expected contribution for the `#big-bees` project is equal to 33.33% ( 100% / 3 ) because their team has 3 players, so an equal contribution is 1/3 of the project.
+
+### Contribution Gap
+
+The contribution gap is the difference between actual and expected contribution. It demonstrates whether a player contributed _more_ or _less_ than is expected of them, based on the size of their team. Represented as a percentage (0-100%).
+
+In the above dataset, the player's contribution gap for the `#big-bees` project is equal to 13.34% ( 46.67% - 33.33% ).
+
+## Contribution Accuracy and Bias
+
+Contribution accuracy and bias reflect how well you estimate your contribution to projects.
+
+To demonstrate how these stats apply, we'll use a modified version of the above dataset, aggregating the team estimates into their average (mean):
+
+| Project      | Self estimate | Team estimate (avg) |
+|:-------------|:--------------|:--------------------|
+| #big-bees    | 50%           | 45%                 |
+| #red-rabbits | 28%           | 30%                 |
+| #tiny-tigers | 20%           | 30%                 |
+
+### Contribution Accuracy
+
+Contribution accuracy reflects how accurate your estimations are relative to the consensus. Represented as a percentage (0-100%).
+
+Zero is equal to perfect accuracy (i.e. you estimate your contribution the same as your peers do). The closer this stat is to zero, the more accurate your contribution estimates are.
+
+Your contribution accuracy _per project_ is the difference between self- and team-estimated contribution as an absolute number. So the contribution accuracy stats for the above projects would be:
+
+| Project      | Accuracy             |
 |:-------------|:---------------------|
 | #tiny-tigers | abs(20% - 30%) = 10% |
 | #big-bees    | abs(50% - 45%) = 5%  |
 | #red-rabbits | abs(28% - 30%) = 2%  |
 
-Based on these projects, your overall **discernment stat** would be the mean of (10%, 5%, 2%), or **5.67%**.
+Based on these projects, the _overall contribution accuracy stat_ is 5.67% (mean of [10%, 5%, 2%]).
+
+## Contribution Bias
+
+Contribution bias reflects whether you tend to over- or under- estimate your contribution. Represented as a percentage (0-100%).
+
+It is calculated the same as contribution accuracy, except that it does turn the difference into an absolute number.
+
+Your contribution bias _per project_ is the difference between self- and team-estimated contribution. So the contribution bias stats for the above projects would be:
+
+| Project      | Bias             |
+|:-------------|:-----------------|
+| #tiny-tigers | 20% - 30% = -10% |
+| #big-bees    | 50% - 45% = 5%   |
+| #red-rabbits | 28% - 30% = -2%  |
+
+Based on these projects, the _overall contribution bias stat_ is -2.33% (mean of [-10%, 5%, -2%]).
 
 ## Time Dedication per Week
 

--- a/Game_Manual/Stats.md
+++ b/Game_Manual/Stats.md
@@ -39,11 +39,11 @@ To demonstrate how the various contribution stats are calculated, we'll use the 
 
 #### Example Project Contribution Estimations
 
-| Project      | Team size | Self estimate | Team estimates |
-|:-------------|:----------|:--------------|:---------------|
-| #big-bees    | 3         | 50%           | 42%, 48%       |
-| #red-rabbits | 4         | 28%           | 27%, 35%, 28%  |
-| #tiny-tigers | 2         | 20%           | 30%            |
+| Project      | Team size | Self estimate | Team estimates | Your Hours | Total Hours |
+|:-------------|:----------|:--------------|:---------------|:-----------|:------------|
+| #big-bees    | 3         | 50%           | 42%, 48%       | 30         | 80          |
+| #red-rabbits | 4         | 28%           | 27%, 35%, 28%  | 25         | 120         |
+| #tiny-tigers | 2         | 20%           | 30%            | 40         | 75          |
 
 ### Actual Contribution
 
@@ -53,15 +53,15 @@ In the above dataset, the player's actual contribution for the `#big-bees` proje
 
 ### Expected Contribution
 
-Your expected contribution how much you are expected to contribute to the project based on the team size so that each player contributes equally. Represented as a percentage (0..100%).
+Your expected contribution how much you are expected to contribute to the project based on how many hours you contribute relative to the total hours of all players. Represented as a percentage (0..100%).
 
-In the above dataset, the player's expected contribution for the `#big-bees` project is equal to 33.33% ( 100% / 3 ) because their team has 3 players, so an equal contribution is 1/3 of the project.
+In the above dataset, the player's expected contribution for the `#big-bees` project is equal to 37.5% ( 30 / 80 ) because they contributed 30 out of a total 80 hours that players spent on this project.
 
 ### Contribution Gap
 
 The contribution gap is the difference between actual and expected contribution. It demonstrates whether a player contributed _more_ or _less_ than is expected of them, based on the size of their team. Represented as a percentage (0..100%).
 
-In the above dataset, the player's contribution gap for the `#big-bees` project is equal to 13.34% ( 46.67% - 33.33% ).
+In the above dataset, the player's contribution gap for the `#big-bees` project is equal to 9.17% ( 46.67% - 37.5% ). In other words, they contributed 9.17% _more_ to the project than what is expected based on how many hours they worked on it.
 
 ## Estimation Accuracy and Bias
 

--- a/Game_Manual/Stats.md
+++ b/Game_Manual/Stats.md
@@ -79,17 +79,17 @@ To demonstrate how these stats apply, we'll use a modified version of the above 
 
 Estimation accuracy reflects how accurate your estimations are relative to the consensus. Represented as a percentage (0..100%).
 
-Zero is equal to perfect accuracy (i.e. you estimate your contribution the same as your peers do). The closer this stat is to zero, the more accurate your contribution estimates are.
+One hundred percent is perfect accuracy: you estimate your contribution the same as your peers do. The closer this stat is to 100%, the more accurate your contribution estimates are.
 
-Your estimation accuracy _per project_ is the difference between self- and team-estimated contribution for that project, using the [absolute value][absolute-values] of that difference. So the estimation accuracy stats for the above projects would be:
+Your estimation accuracy _per project_ is computed by first finding difference between self- and team-estimated contribution for that project, and then using the [absolute value][absolute-values] of that difference. Finally, this number is subtracted from 100% (so that a perfect score would be 100%, not 0%). So the estimation accuracy stats for the above projects would be:
 
-| Project      | Estimation Accuracy                  |
-|:-------------|:-------------------------------------|
-| #tiny-tigers | abs(20% - 30%) = abs(-10%) = **10%** |
-| #big-bees    | abs(50% - 45%) = abs(5%) = **5%**    |
-| #red-rabbits | abs(28% - 30%) = abs(-2%) = **2%**   |
+| Project      | Estimation Accuracy                          |
+|:-------------|:---------------------------------------------|
+| #tiny-tigers | 100% - abs(20% - 30%) = 100% - 10% = **90%** |
+| #big-bees    | 100% - abs(50% - 45%) = 100% - 5% = **95%**  |
+| #red-rabbits | 100% - abs(28% - 30%) = 100% - 2% = **98%**  |
 
-Based on these projects, the _overall estimation accuracy stat_ is 5.67% (average of [10%, 5%, 2%]).
+Based on these projects, the _overall estimation accuracy stat_ is 94.33% (average of [90%, 95%, 98%]).
 
 ## Estimation Bias
 
@@ -101,15 +101,13 @@ If your estimation bias is _above zero_, that means that you tend to overestimat
 
 If your estimation bias is _exactly zero_, congratulations! You must be a mind-reader, and/or exceptionally self-aware.
 
-Estimation bias is calculated the same as estimation accuracy, except that it does _not_ use the absolute values of the difference between self and team estimates.
-
 Your estimation bias _per project_ is the difference between self- and team-estimated contribution for that project. So the estimation bias stats for the above projects would be:
 
-| Project      | Estimation Bias  |
-|:-------------|:-----------------|
-| #tiny-tigers | 20% - 30% = -10% |
-| #big-bees    | 50% - 45% = 5%   |
-| #red-rabbits | 28% - 30% = -2%  |
+| Project      | Estimation Bias      |
+|:-------------|:---------------------|
+| #tiny-tigers | 20% - 30% = **-10%** |
+| #big-bees    | 50% - 45% = **5%**   |
+| #red-rabbits | 28% - 30% = **-2%**  |
 
 Based on these projects, the _overall estimation bias stat_ is -2.33% (average of [-10%, 5%, -2%]).
 


### PR DESCRIPTION
Move away from any mention of "relative" contributions. Instead, use terms: actual contribution, expected contribution, and contribution gap.

Rename discernment and discernment bias to contribution accuracy and contribution bias.
