### PR TITLE
Change heading to Resource Links

### DIFF
--- a/General/Resource_Links.md
+++ b/General/Resource_Links.md
@@ -1,4 +1,4 @@
-# Resources Links
+# Resource Links
 
 ### LOS
 - [Playbook](https://playbook.learnersguild.org/)


### PR DESCRIPTION
Change heading from "Resources Links" to "Resource Links" for consistency and accuracy.