### PR TITLE
Move to immutable goals: update proj kickoff

### DIFF
--- a/Learning_Guide/Kickoff.md
+++ b/Learning_Guide/Kickoff.md
@@ -12,31 +12,31 @@ The first couple of hours of a project are critical to the success of your learn
 
 Once projects have been formed, the first thing the team needs to do is to create a container for the **artifact**. The artifact is the output of a project. It is the thing produced by a team to complete a project. All artifacts need a URL and a Learning Contract document in a `CONTRACT.md` file.
 
-In most cases, the artifact will be a GitHub repository in the account of a learner on the team that is forked from the goal repository.
+In most cases, the artifact will be a GitHub repository in the account of a learner on the team. If the goal has its own base repo, you can fork it to create this repo.
 
-- Create a repo for your project by forking the goal repository\* and make a simple first commit. Your first commit should write or update the README.md file with your project's name, team members, a link to the goal and a LICENSE file (unless it already exists).
+- Create a repo for your project (or fork the goal repository, if it exists\*) and make a simple first commit. Your first commit should write or update the README.md file with your project's name, team members, a link to the goal and a LICENSE file (unless it already exists).
 - Once you've done that, set the artifact for your project. For example: `/project set-artifact http://github.com/LearnersGuild/playbook`
 
 Make your first commit to a master branch. You should aim to have this step done **within a few minutes** of finding your team.
 
-\*Most goals should come with a goal repository, so the best way to get started is to fork that repository. In some cases, the goal won't have an associated repo, so you'll need to create a new one for your project. Some goals (like the OSS projects) have a different process for project kickoff. Read the goal for more information.
+\*Some goals come with a goal repository, so the best way to get started is to fork that repository. In some cases, the goal won't have an associated repo, so you'll need to create a new one for your project. Other goals (like the OSS projects) may have a different process for project kickoff. Read the goal for more information.
 
 ## Learning Contract
 
-Once your first commit is in, it's time to review the scope of your project by reading the Learning Contract in the `CONTRACT.md` file. The Learning Contract document defines the specifications and quality criteria for the artifact to meet.
+Once your first commit is in, it's time to review the scope of your project by creating a Learning Contract.
+
+Name it `CONTRACT.md` and copy over the contents of the goal's learning contract (which should be in the `contracts/` directory of the [web-development-js](https://github.com/GuildCrafts/web-development-js/tree/master/contracts) repo). The Learning Contract document defines the specifications and quality criteria for the artifact to meet.
 
 The goal of a Learning Contract is to guide your team's effort for the rest of the project. It is a **learning contract** that you make with yourselves and has many purposes:
 
 1. It guides and focuses your efforts for the rest of the cycle.
 2. It defines completeness and quality for your code reviewers during the reflection phase.
-3. It is a means for you to practice **project estimation**, **spec'ing**, and **goal setting**. These are critical skill for any software developer to develop (and really difficult ones).
+3. It serves as an example of **project estimation**, **spec'ing**, and **goal setting**. Read the contract with a critical eye to see how this is done. To practice this skill (it is an important one!), consider writing your own goal!
 4. It challenges you and your team to stay in your Zone of Proximal Development (ZPD). Without a good challenge, your learning will not be optimized.
-
-Review the Learning Contract included in the goal. You may need to improve it if the specs are unclear or the quality rubric is incomplete. If so, make changes in a pull request and then submit your PR to [prrr](http://prrr.apps.learnersguild.org/).
 
 Checkout this [example of a model spec](https://github.com/GuildCrafts/model-project-specifications/blob/master/model_specs.md) and this [quality rubric library](https://github.com/GuildCrafts/model-project-specifications/blob/master/quality_rubric_library.md).
 
-If you notice that the specs for the goal are too vague or incomplete, inform the goal author and request that they update them.
+If you notice that the specs for the goal are too vague or incomplete, inform the goal author and request that they update them. Or, better yet, just submit a pull request with your improvements as changes to the source learning contract.
 
 ## Work Plan
 
@@ -60,7 +60,7 @@ Some of the things you might want to cover:
 - How do you address any pinches or misunderstandings in communication?
 - Exchange phone numbers if comfortable to do so for communication purposes.
 
-**You should plan 15 to 20 minutes for this conversation. Don't spend too much time on it, and don't skip it**
+**You should plan 15 to 20 minutes for this conversation. Don't spend too much time on it, and don't skip it.**
 
 ## Guidelines for OSS projects
 

--- a/Learning_Guide/Kickoff.md
+++ b/Learning_Guide/Kickoff.md
@@ -6,106 +6,41 @@ The purpose of a project is for the team to achieve the goal through practicing 
 
 The first couple of hours of a project are critical to the success of your learning for the week. Investing time and attention getting the kickoff right, can go a long way to maximizing your learning for the week.
 
-**You should budget around 1.5 hours for the project kickoff, and it shouldn't take you more than 2**
+**You should budget around 30 minutes for the project kickoff, and it shouldn't take you more than an hour.**
 
 ## First Commit
 
-Once projects have been formed, the first thing the team needs to do is to create a container for the **artifact**. The artifact is the output of a project. It is the thing produced by a team to complete a project. All artifacts need a URL and a Learning Contract document. In most cases, the artifact will be a GitHub repository in the account of a learner on the team.
+Once projects have been formed, the first thing the team needs to do is to create a container for the **artifact**. The artifact is the output of a project. It is the thing produced by a team to complete a project. All artifacts need a URL and a Learning Contract document in a `CONTRACT.md` file.
 
-- Create a repo for your project, and make a simple first commit. Your first commit should contain a README.md file with your project's name, team members, a link to the goal and a LICENSE.MD file.
+In most cases, the artifact will be a GitHub repository in the account of a learner on the team that is forked from the goal repository.
+
+- Create a repo for your project by forking the goal repository\* and make a simple first commit. Your first commit should write or update the README.md file with your project's name, team members, a link to the goal and a LICENSE file (unless it already exists).
 - Once you've done that, set the artifact for your project. For example: `/project set-artifact http://github.com/LearnersGuild/playbook`
 
 Make your first commit to a master branch. You should aim to have this step done **within a few minutes** of finding your team.
 
+\*Most goals should come with a goal repository, so the best way to get started is to fork that repository. In some cases, the goal won't have an associated repo, so you'll need to create a new one for your project. Some goals (like the OSS projects) have a different process for project kickoff. Read the goal for more information.
 
 ## Learning Contract
 
-
-#### Overview
-
-Once your first commit is in, it's time to scope your project by creating a Learning Contract. The Learning Contract document defines the specifications and quality criteria for the artifact to meet.
+Once your first commit is in, it's time to review the scope of your project by reading the Learning Contract in the `CONTRACT.md` file. The Learning Contract document defines the specifications and quality criteria for the artifact to meet.
 
 The goal of a Learning Contract is to guide your team's effort for the rest of the project. It is a **learning contract** that you make with yourselves and has many purposes:
 
 1. It guides and focuses your efforts for the rest of the cycle.
 2. It defines completeness and quality for your code reviewers during the reflection phase.
-3. It is a means for you to practice **project estimation**, **specing**, and **goal setting**. These are critical skill for any software developer to develop (and really difficult ones)
+3. It is a means for you to practice **project estimation**, **spec'ing**, and **goal setting**. These are critical skill for any software developer to develop (and really difficult ones).
 4. It challenges you and your team to stay in your Zone of Proximal Development (ZPD). Without a good challenge, your learning will not be optimized.
 
-#### Preparing for the contract
+Review the Learning Contract included in the goal. You may need to improve it if the specs are unclear or the quality rubric is incomplete. If so, make changes in a pull request and then submit your PR to [prrr](http://prrr.apps.learnersguild.org/).
 
-Before writing your Learning Contract, it's good practice to checkin with your team about the following:
+Checkout this [example of a model spec](https://github.com/GuildCrafts/model-project-specifications/blob/master/model_specs.md) and this [quality rubric library](https://github.com/GuildCrafts/model-project-specifications/blob/master/quality_rubric_library.md).
 
-- How familiar are they with this goal? Have they done it before? What have they learned?
-- How available are they for the week? Do they have any planned personal time off?
-- How familiar are they with the technology stack suggested by the goal (if any)?
-- Is this is a normal week, or are there any holidays / special events that will shorten it?
+If you notice that the specs for the goal are too vague or incomplete, inform the goal author and request that they update them.
 
-Once you've surveyed your teams' skill and availability, it's time to solidify the specs:
+## Work Plan
 
-**You should aim to write specs that are clear, and detailed, and challenging. They should put the entire team in their ZPD for the rest of the week. The goal is to maximize quantity and quality of software shipped. The Learning Contract should challenge everyone on the team, *not* to make sure everyone is comfortable.**
-
-To create a Learning Contract, create a new `contract` branch:
-
-```
-git branch contract
-git checkout contract
-git push origin contract
-```
-
-Copy the text of the goal into the `README.md` file.
-
-
-#### Specifications and Quality Criteria
-
-After creating the Learning Contract, the team must edit the document to define the scope of features and quality criteria for their project.
-
-The scope of features is determined by the set of specifications for the project. It is used to measure _completeness_.
-
-The quality criteria are rules that govern how the artifact should be produced. They are used to measure _quality_.
-
-To define the scope, add, edit, or remove specifications from the list. The team is accountable for producing an artifact that satisfies _all_ of the specifications, so be realistic.
-
-Discuss the specs with your team, and adjust them as you see fit to get to a scope that will provide an appropriate level of difficulty and "stretch".
-
-To set quality criteria, choose 2 or 3 rules or guidelines that, as a team, you agree to follow to ensure a quality artifact. Add these to the Learning Contract.
-
-For example, a quality criteria might be "Follow object-oriented principles in all program design" or "Write good commit messages using these rules: http://chris.beams.io/posts/git-commit/".
-
-Checkout this [example of a model spec](https://github.com/GuildCrafts/model-project-specifications/blob/master/model_specs.md) and this [quality rubric library](https://github.com/GuildCrafts/model-project-specifications/blob/master/quality_rubric_library.md)
-
-#### Commitment and Review
-
-Once a proper Learning Contract document has been written and agreed on, it's good practice to go around your team and give a number from 1 to 10 that signals how much of a stretch they think it will be to accomplish this work:
-
-Use the following values to calibrate:
-
-    1 = Extremely bored
-    4 = Confident and comfortable
-    6 = Stretched but still capable
-    7 = In flow and pushed just beyond capacity
-    8 = Slightly more challenged than is fun
-    10 = Completely overwhelmed
-
-**If any team member is less than a seven, then you should take the time to increase the difficulty of the project by adding more specs, or raising the quality bar**
-
-Once the Learning Contract is set, push the contract branch to github:
-
-```
-git push origin contract
-```
-
-And create a pull request: Go to your repository on GitHub and click on the 'Pull Request' button at the top right of the window:
-
-![Pull Request](/images/pull_request_1.png)
-
-And finally, submit a link to your pull request to [prrr](http://prrr.apps.learnersguild.org). A coach will review it and give you feedback on the quality of your specs and rubrics.
-
-**On average, it should take your team about an hour to push your Learning Contract for review, and no more than two hours. If it's taking more than that, you're probably getting too mired in product design and should get some support to make some decisions and move on**
-
-#### Work Plan
-
-While the spec is being reviewed, it's time to checkin with your team and plan how you'll work together.
+Next up: time to checkin with your team and plan how you'll work together.
 
 Some of the things you might want to cover:
 
@@ -127,31 +62,9 @@ Some of the things you might want to cover:
 
 **You should plan 15 to 20 minutes for this conversation. Don't spend too much time on it, and don't skip it**
 
-#### Check on your contract review
-
-Check on your PR,
-
-- If it's been reviewed and merged, read the review comments and begin your work
-- If it has been reviewed but not merged, incorporate the feedback to the learning contract, and submit it for another review
-
-- Don't being your project unless your Learning Contract PR has been reviewed **and merged**.
-
-If you're waiting for a review, then jump on [prrr](http://prrr.apps.learnersguild.org) and claim a pending review for another project's learning contract and review it.
-
-## Reviewing another Team's Learning Contract
-
-When reviewing another Team's Learning Contract, make sure you cover the following:
-
-- The README.MD has the project's name, team members, and a link to the goal
-- There is a proper LICENSE.MD file
-- The project specs are clear, detailed and unambiguous. They don't leave too much room for interpretation. You can imagine yourself using them to review the completeness of the project
-- The quality rubric is clear and unambiguous. You can imagine yourself using it to review the quality of the project
-
-Once you're confident the Learning Contract passes the above criteria, **approve the pull request and merge it**. If the contract needs to be improved on before passing, make the suggestions and do not merge it. Wether you've accepted the contract or not, please be generous with your suggestions for improvement.
-
 ## Guidelines for OSS projects
 
-If you are working on an OSS project, you should spend the project kickoff getting clear on which issues from the backlog you're committing to. Create a gist with links to the issues you will be working on and set it as your project artifact. No need to use Prrrr or get your issues reviewed since your Project Lead is making sure the specs are clear and they will be the ones doing the project review at the end of the cycle. 
+If you are working on an OSS project, you should spend the project kickoff getting clear on which issues from the backlog you're committing to. Create a gist with links to the issues you will be working on and set it as your project artifact. No need to use Prrrr or get your issues reviewed since your Project Lead is making sure the specs are clear and they will be the ones doing the project review at the end of the cycle.
 
 
 ## FAQ


### PR DESCRIPTION
- No more learning contract creation/review process as default (only in
  cases where specs are unclear)
- Assume that goals have pre-defened goal repo w/ CONTRACT.md

See https://github.com/GuildCrafts/web-development-js/pull/155 for more context on the switch to using goals as repos.