### PR TITLE
Fixed git command that grabs commit hash

### DIFF
--- a/Learning_Guide/Review.md
+++ b/Learning_Guide/Review.md
@@ -4,8 +4,8 @@
 
 **Step 1:** You first need to find out the commit hash for the first commit in the repository, which you can do with:
 
-```
-$ git rev-list --all --author YOUR-GITHUB-USERNAME | tail -1
+```sh
+$ git rev-list --all --author $(git config --get user.email) | tail -1
 ec2287e5837386c54fbd082021530aa18c0dcf18
 ```
 

--- a/Learning_Guide/Review.md
+++ b/Learning_Guide/Review.md
@@ -5,7 +5,7 @@
 **Step 1:** You first need to find out the commit hash for the first commit in the repository, which you can do with:
 
 ```
-$ git rev-list --all | tail -1
+$ git rev-list --all --author YOUR-GITHUB-USERNAME | tail -1
 ec2287e5837386c54fbd082021530aa18c0dcf18
 ```
 


### PR DESCRIPTION
The original git command returned the hash from the first commit in the
repo ever.

The revised command will return the hash from the first commit written
by the player only.