### PR TITLE
Change min reviews required for RXP calculation

### DIFF
--- a/Game_Manual/Stats.md
+++ b/Game_Manual/Stats.md
@@ -382,10 +382,10 @@ for each project that a player reviewed (internal or external review)
   projectReviewAccuracy = 100 - reviewDelta
 
 // overall stat
-reviewAccuracy = projectReviewCount < 7 ? null : mean(20 most recent projectReviewAccuracy scores)
+reviewAccuracy = projectReviewCount < 8 ? null : mean(20 most recent projectReviewAccuracy scores)
 ```
 
-We don't start computing accuracy for a player until that player has passed a threshold of 7 reviews. With fewer reviews that that we really don't have enough information to judge their accuracy.
+We don't start computing accuracy for a player until that player has passed a threshold of 8 reviews. With fewer reviews that that we really don't have enough information to judge their accuracy.
 
 ### Review Experience (RXP)
 


### PR DESCRIPTION
Every current non-SEP player will be given an external review count of 1 to start, instead of 0, because it's easier to do that than to teach the code to handle the special case of a player somehow having earned some accuracy without ever submitting a review. 

Since that moves everyone one review closer to the minimum needed to calculate RXP, I've changed that threshold from 7 to 8.